### PR TITLE
Added evil-mode indicator support without interfering with those who don't use evil.

### DIFF
--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -122,7 +122,7 @@
                                                (propertize "RO " 'face 'bold))
                                            "")))
 
-(defvar zerodark-modeline-evil '(:eval (if evil-mode
+(defvar zerodark-modeline-evil '(:eval (if (and evil-mode (featurep 'powerline-evil))
                                            (propertize (powerline-evil-tag) 'face 'bold) "")))
 
 (defvar zerodark-buffer-coding '(:eval (unless (eq buffer-file-coding-system (default-value 'buffer-file-coding-system))

--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -30,6 +30,8 @@
 (require 's)
 (require 'all-the-icons)
 (require 'powerline)
+(when (require 'powerline-evil nil 'noerror)
+  (require 'powerline-evil))
 
 (defmacro cached-for (secs &rest body)
   "Cache for SECS the result of the evaluation of BODY."
@@ -120,6 +122,9 @@
                                                    (propertize "RO " 'face 'zerodark-ro-alt-face))
                                                (propertize "RO " 'face 'bold))
                                            "")))
+
+(defvar zerodark-modeline-evil '(:eval (if evil-mode
+                                           (propertize (powerline-evil-tag) 'face 'bold) "")))
 
 (defvar zerodark-buffer-coding '(:eval (unless (eq buffer-file-coding-system (default-value 'buffer-file-coding-system))
                                          mode-line-mule-info)))
@@ -778,6 +783,7 @@ The result is cached for one second to avoid hiccups."
                 `(,zerodark-modeline-bar-alt
                   "%e"
                   ,zerodark-modeline-ro-alt " "
+                  ,zerodark-modeline-evil
                   ,zerodark-buffer-coding
                   mode-line-frame-identification " "
                   " "

--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -30,8 +30,7 @@
 (require 's)
 (require 'all-the-icons)
 (require 'powerline)
-(when (require 'powerline-evil nil 'noerror)
-  (require 'powerline-evil))
+(require 'powerline-evil nil 'noerror)
 
 (defmacro cached-for (secs &rest body)
   "Cache for SECS the result of the evaluation of BODY."
@@ -714,6 +713,7 @@ The result is cached for one second to avoid hiccups."
                 `("%e"
                   ,zerodark-modeline-bar
                   ,zerodark-modeline-ro
+                  ,zerodark-modeline-evil
                   ,zerodark-buffer-coding
                   mode-line-frame-identification " "
                   " "


### PR DESCRIPTION
This very minor pull request loads the powerline-evil package only if it is installed. If installed it displays the current evil mode the user is in. If it's not installed the package will function exactly as it would before.
