### PR TITLE
Theme ivy-highlight-face

### DIFF
--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -549,6 +549,7 @@ The result is cached for one second to avoid hiccups."
    `(ivy-match-required-face ((,class (:foreground ,red :background ,background-red :weight bold))))
    `(ivy-modified-buffer ((,class (:foreground ,red))))
    `(ivy-remote ((,class (:foreground ,blue))))
+   `(ivy-highlight-face ((,class (:foreground ,blue :weight bold))))
 
    ;; helm
    `(helm-candidate-number ((,class (:weight bold))))


### PR DESCRIPTION

![screenshot from 2017-11-26 11-20-29](https://user-images.githubusercontent.com/217543/33239226-9293961c-d29d-11e7-9790-61b92354dffa.png)
This face is used when a candidate is from a special category. This is
used by, e.g., counsel-describe-function to differentiate commands
from functions.