### PR TITLE
Do not require flycheck (Fix #61 & #67)

### DIFF
--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -143,7 +143,7 @@
 
 (defun zerodark-modeline-flycheck-status ()
   "Return the status of flycheck to be displayed in the mode-line."
-  (when flycheck-mode
+  (when (and (boundp 'flycheck-mode) flycheck-mode)
     (let* ((text (pcase flycheck-last-status-change
                    (`finished (if flycheck-current-errors
                                   (let ((count (let-alist (flycheck-count-errors flycheck-current-errors)


### PR DESCRIPTION
Although the Flycheck dependency was removed (so it is not installed along with this package), due to the way the code in this package is written, it still implicitly requires Flycheck to be installed.  Otherwise, this package will throw an error due to `flycheck-mode` not being bound (on the changed line).

It looks like you provided a fix here, in a branch: https://github.com/NicolasPetton/zerodark-theme/issues/61#issuecomment-448370704

And the OP from that issue seems to have tried the fix _on that branch_ and confirmed that it worked for him, so he closed the issue.

However, I don't see evidence in the commit history that branch was actually merged into `master`.  So the issue still persists.