### PR TITLE
Prevent errors from missing optional dependencies (fix #67)

### DIFF
--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -61,7 +61,8 @@
   :type 'boolean)
 
 (defcustom zerodark-theme-display-vc-status 'full
-  "Control how version control information is displayed."
+  "Control how version control information is displayed.
+Note that `magit' must also be installed."
   :type '(choice (const :tag "Display fork symbol and branch name" 'full)
                  (const :tag "Display fork symbol only" t)
                  (const :tag "Do not display any version control information" nil)))
@@ -130,6 +131,7 @@
 (defvar zerodark-buffer-coding '(:eval (unless (eq buffer-file-coding-system (default-value 'buffer-file-coding-system))
                                          mode-line-mule-info)))
 
+;; `magit' must be installed in order to evaluate this.
 (defvar zerodark-modeline-vc '(vc-mode ("   "
                                         (:eval (all-the-icons-faicon "code-fork"
                                                                      :height 0.9
@@ -192,7 +194,8 @@
 
 (defun zerodark-git-face ()
   "Return the face to use based on the current repository status.
-The result is cached for one second to avoid hiccups."
+The result is cached for one second to avoid hiccups.
+`magit' must be installed in order to call this function."
   (funcall zerodark--git-face-cached))
 
 
@@ -825,7 +828,10 @@ The result is cached for one second to avoid hiccups."
                   " "
                   ,zerodark-modeline-buffer-identification
                   ,zerodark-modeline-position
-                  ,(if zerodark-theme-display-vc-status
+                  ;; Check if magit is installed and simultaneously ensure its
+                  ;; functions are loaded:
+                  ,(if (and (require 'magit nil 'noerror)
+                            zerodark-theme-display-vc-status)
                        zerodark-modeline-vc
                      "")
                   "  "

--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -813,7 +813,6 @@ The result is cached for one second to avoid hiccups."
 (defun zerodark-setup-modeline-format ()
   "Setup the mode-line format for zerodark."
   (interactive)
-  (require 'magit)
   (require 'all-the-icons)
   (setq-default mode-line-format
                 `("%e"

--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -813,7 +813,6 @@ The result is cached for one second to avoid hiccups."
 (defun zerodark-setup-modeline-format ()
   "Setup the mode-line format for zerodark."
   (interactive)
-  (require 'flycheck)
   (require 'magit)
   (require 'all-the-icons)
   (setq-default mode-line-format

--- a/zerodark-theme.el
+++ b/zerodark-theme.el
@@ -143,7 +143,7 @@
 
 (defun zerodark-modeline-flycheck-status ()
   "Return the status of flycheck to be displayed in the mode-line."
-  (when flycheck-mode
+  (when (and (boundp 'flycheck-mode) flycheck-mode)
     (let* ((text (pcase flycheck-last-status-change
                    (`finished (if flycheck-current-errors
                                   (let ((count (let-alist (flycheck-count-errors flycheck-current-errors)


### PR DESCRIPTION
When `(zerodark-setup-modeline-format)` was called, it would signal errors if `flycheck` or `magit` were not installed.  However by adding some guards I was able to make the modeline render without errors, even if the dependencies are missing.  This should make them "truly optional" now.

I tested both with and without Flycheck/Magit and it seems to work fine in either case for me.